### PR TITLE
Update submodules in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.8
 
+RUN apt update && apt install -y git
+
 WORKDIR /app
 
 RUN pip install poetry
@@ -9,5 +11,7 @@ COPY pyproject.toml /app/pyproject.toml
 RUN poetry install
 
 COPY . /app
+
+RUN git submodule update --init
 
 CMD ["poetry", "run", "hypercorn", "main:app", "--bind", "0.0.0.0:80"]


### PR DESCRIPTION
This fetches the submodules in the Docker image build to have the branding repository ready by the time the app starts, preventing the error we experienced while trying to deploy:
```
FileNotFoundError: [Errno 2] No such file or directory: 'branding/quackstack/silverduck_templates'
```