### PR TITLE
fix: call time function when generating random duck hash

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ async def get_duck(duck: Optional[DuckRequest] = None) -> Dict[str, Any]:
         if not file.exists():
             DuckBuilder.generate(duck).save(file)
     else:
-        dh = sha1(str(time).encode()).hexdigest()
+        dh = sha1(str(time()).encode()).hexdigest()
         file = CACHE / f"{dh}.png"
 
         DuckBuilder.generate().save(file)


### PR DESCRIPTION
Before this each random generation would save to the same file when this was not intended, now it calls time() so that a new hash is generated for the filename each time