### PR TITLE
Add cache-to key to build job to enable Docker layers caching

### DIFF
--- a/.github/workflows/quackstack.yml
+++ b/.github/workflows/quackstack.yml
@@ -119,6 +119,7 @@ jobs:
           file: ./Dockerfile
           push: true
           cache-from: type=registry,ref=ghcr.io/python-discord/quackstack:main
+          cache-to: type=inline
           tags: |
             ghcr.io/python-discord/quackstack:main
             ghcr.io/python-discord/quackstack:${{ steps.sha_tag.outputs.tag }}


### PR DESCRIPTION
In order to enable caching of D~~u~~ocker layers, `cache-to` key is required in the build action.