### PR TITLE
Change CI step names

### DIFF
--- a/.github/workflows/quackstack.yml
+++ b/.github/workflows/quackstack.yml
@@ -1,4 +1,4 @@
-name: Duckinuous Quackration
+name: Build & Deploy Quackstack
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    name: DuckLint
+    name: Lint
     runs-on: ubuntu-latest
     env:
       # Configure pip to cache dependencies and do a user install
@@ -87,7 +87,7 @@ jobs:
         --format='::error file=%(path)s,line=%(row)d,col=%(col)d::[flake8] %(code)s: %(text)s'"
 
   build:
-    name: Build & Quack
+    name: Build & Push
     runs-on: ubuntu-latest
 
     needs: [lint]
@@ -125,7 +125,7 @@ jobs:
             ghcr.io/python-discord/quackstack:${{ steps.sha_tag.outputs.tag }}
 
   deploy:
-    name: Continuous Ducky
+    name: Deploy to Kubernetes
     runs-on: ubuntu-latest
 
     needs: [build]

--- a/.github/workflows/quackstack.yml
+++ b/.github/workflows/quackstack.yml
@@ -87,7 +87,7 @@ jobs:
         --format='::error file=%(path)s,line=%(row)d,col=%(col)d::[flake8] %(code)s: %(text)s'"
 
   build:
-    name: Build & Push
+    name: Build & Push Docker image
     runs-on: ubuntu-latest
 
     needs: [lint]


### PR DESCRIPTION
Reverts CI stage names to a bit of normalcy. Whilst duck puns are great, I don't think CI stages is a place for them, and it simply adds confusion (e.g. `Build & Quack`, what is Quack?).