### PR TITLE
fix ducky saving after switch to new return type

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,12 +34,12 @@ async def get_duck(duck: Optional[DuckRequest] = None) -> Dict[str, Any]:
         file = CACHE / f"{dh}.png"
 
         if not file.exists():
-            DuckBuilder.generate(duck).save(file)
+            DuckBuilder.generate(duck).image.save(file)
     else:
         dh = sha1(str(time()).encode()).hexdigest()
         file = CACHE / f"{dh}.png"
 
-        DuckBuilder.generate().save(file)
+        DuckBuilder.generate().image.save(file)
 
     return {"file": f"/static/{dh}.png"}
 


### PR DESCRIPTION
The return type for duck building is now a named tuple with an image argument, rather than an image, causing the server to error when trying to save the duck (calling .save() on the namedtuple), this PR fixes that issue.