### PR TITLE
remove git submodule update from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,4 @@ RUN poetry install
 
 COPY . /app
 
-RUN git submodule update --init
-
 CMD ["poetry", "run", "hypercorn", "main:app", "--bind", "0.0.0.0:80"]


### PR DESCRIPTION
As of #25 we no longer use the branding repo as a submodule and hence have no submodules, so this removed the submodule update step from the dockerfile