### PR TITLE
Dockerfile: don't install dev dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN pip install poetry
 
 COPY pyproject.toml /app/pyproject.toml
 
-RUN poetry install
+RUN poetry install --no-dev
 
 COPY . /app
 


### PR DESCRIPTION
Development :clap: dependencies :clap: should :clap: never :clap: be :clap: installed :clap: in :clap: a :clap: container

For real though, this takes time and build space and I doubt anyone is linting their code from within the container. Even if you do, you can run `poetry install` again to have development dependencies.