### PR TITLE
Allow to pass options while generating Man Ducks

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from fastapi.staticfiles import StaticFiles
 
 from src.ducky import DuckBuilder
 from src.manducky import ManDuckGenerator
-from src.models import DuckRequest
+from src.models import DuckRequest, ManDuckRequest
 
 CACHE = Path(getenv("LOCATION", "./static"))
 
@@ -45,13 +45,22 @@ async def get_duck(duck: Optional[DuckRequest] = None) -> Dict[str, Any]:
 
 
 @app.get("/manduck")
-async def get_man_duck() -> Dict[str, Any]:
+async def get_man_duck(manduck: Optional[ManDuckRequest] = None) -> Dict[str, Any]:
     """Create a new man_duck."""
-    dh = sha1(str(time()).encode()).hexdigest()
+    if manduck:
+        dh = dicthash(manduck.dict())
+        file = CACHE / f"{dh}.png"
 
-    ducky = DuckBuilder.generate()
-    ducky = ManDuckGenerator(ducky).generate()
-    ducky.image.save(CACHE / f"{dh}.png")
+        if not file.exists():
+            ducky = ManDuckGenerator().generate(options=manduck)
+            ducky.image.save(CACHE / f"{dh}.png")
+
+    else:
+        dh = sha1(str(time()).encode()).hexdigest()
+
+        ducky = DuckBuilder.generate()
+        ducky = ManDuckGenerator().generate(ducky=ducky)
+        ducky.image.save(CACHE / f"{dh}.png")
 
     return {"file": f"/static/{dh}.png"}
 

--- a/src/ducky.py
+++ b/src/ducky.py
@@ -6,14 +6,13 @@ from typing import Optional, Tuple
 from PIL import Image, ImageChops
 from fastapi import HTTPException
 
-from .colors import make_duck_colors
+from .colors import DuckyColors, make_duck_colors
 from .models import DuckRequest
 
 ASSETS_PATH = Path("duck-builder", "ducky")
 DUCK_SIZE = (499, 600)
 
 ProceduralDucky = namedtuple("ProceduralDucky", "image colors hat equipment outfit")
-DuckyColors = namedtuple("DuckyColors", "eye eye_wing wing body beak")
 
 
 class DuckBuilder:

--- a/src/manducky.py
+++ b/src/manducky.py
@@ -28,7 +28,6 @@ class ManDuckGenerator:
     ) -> dict:
         """Generate a man duck structure from given configuration."""
         variation = f"variation_{variation_}"
-        print(dress_colors)
 
         template = {
             "head": (
@@ -79,7 +78,7 @@ class ManDuckGenerator:
 
         return template
 
-    def generate_from_options(self, options: Optional[ManDuckRequest]) -> dict:
+    def generate_from_options(self, options: dict) -> dict:
         """Generate a man duck from the provided request."""
         colors = DuckyColors(**options["colors"])
         accessories = options["accessories"]
@@ -98,7 +97,7 @@ class ManDuckGenerator:
     ) -> ManDucky:
         """Actually generate the man ducky from the provided request, else generate a random one.."""
         if options:
-            template = self.generate_from_options(options)
+            template = self.generate_from_options(options.dict())
         else:
             template = self.generate_tempalte(
                 ducky, make_man_duck_colors(), random.choice((1, 2))
@@ -112,5 +111,7 @@ class ManDuckGenerator:
     def apply_layer(self, layer: Image.Image, recolor: Optional[Color] = None) -> None:
         """Add the given layer on top of the ducky. Can be recolored with the recolor argument."""
         if recolor:
+            if isinstance(recolor, dict):
+                recolor = tuple(recolor.values())
             layer = ImageChops.multiply(layer, Image.new("RGBA", MAN_DUCKY_SIZE, color=recolor))
         self.output.alpha_composite(layer)

--- a/src/manducky.py
+++ b/src/manducky.py
@@ -1,3 +1,4 @@
+import os
 import random
 from collections import namedtuple
 from pathlib import Path
@@ -114,7 +115,10 @@ class ManDuckGenerator:
         try:
             layer = Image.open(layer_path)
         except FileNotFoundError:
-            raise HTTPException(400, "Invalid option provided.")
+            raise HTTPException(
+                400,
+                f"Invalid option provided: {os.path.basename(layer_path)} not found."
+            )
 
         if recolor:
             if isinstance(recolor, dict):

--- a/src/models.py
+++ b/src/models.py
@@ -21,6 +21,13 @@ class Colors(BaseModel):
     eye_wing: PartOption
 
 
+class DressColors(BaseModel):
+    """Valid options for a man ducky dress colors."""
+
+    shirt: PartOption
+    pants: Optional[PartOption]
+
+
 class Accessories(BaseModel):
     """Valid accessories for a duck."""
 
@@ -33,4 +40,13 @@ class DuckRequest(BaseModel):
     """A request for a ducky generation."""
 
     colors: Colors
+    accessories: Accessories
+
+
+class ManDuckRequest(BaseModel):
+    """A request for a man ducky generation."""
+
+    variation: int
+    colors: Colors
+    dress_colors: DressColors
     accessories: Accessories


### PR DESCRIPTION
## Relevant Issues
Closes #33


## Description
This PR does few miscellaneous changes and the major change: allows to pass options while generating a _cute_ man duck.

#### Miscellaneous Changes:

- Moves all Color named-tuples to `src/colors.py`, to keep them together and not define them at multiple places.
- Changes `ManDucky` named-tuple to only hold `image` as rest options aren't needed.

#### Major Change
This PR adds two models, one for the Dress Colors of man-ducks and other is the options for generating a man-duck.

This also refactors the man-duck code to not make it repetitive and for each `key` in the `template` for generation, there is a tuple, this tuple contains two elements,  i.e. `Image` object and the color for that object, if there is no color then it is a empty object.
