### PR TITLE
(hotfix): Correct order of ProceduralDucky namedtuple

### DIFF
--- a/src/ducky.py
+++ b/src/ducky.py
@@ -78,7 +78,7 @@ class DuckBuilder:
         for item in template.values():
             self.apply_layer(*item)
 
-        return ProceduralDucky(self.output, colors, hat, outfit, equipment)
+        return ProceduralDucky(self.output, colors, hat, equipment, outfit)
 
     def apply_layer(self, layer_path: str, recolor: Optional[Tuple[int, int, int]] = None) -> None:
         """Add the given layer on top of the ducky. Can be recolored with the recolor argument."""


### PR DESCRIPTION
Earlier it used to send a `404` HTTPError since the `equipment` was set as `outfit` and `outfit` as `equipment`.
```json
{"detail":"Invalid option provided: lightsaber.png not found."}
```