### PR TITLE
chore: switch around docs urls

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ CACHE = Path(getenv("LOCATION", "./static"))
 
 CACHE.mkdir(exist_ok=True)
 
-app = FastAPI()
+app = FastAPI(docs_url="swagger_docs", redoc_url="/docs")
 
 app.mount("/static", StaticFiles(directory=CACHE), name="static")
 


### PR DESCRIPTION
Since redoc is easier to understand and easier on the eyes at a glance, this switches around the default docs locations:
- `/docs` is now the redoc endpoint
- `/swagger-docs` is now the endpoint for the default swagger generated docs