### PR TITLE
(details): Rework /details endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ async def get_man_duck(manduck: Optional[ManDuckRequest] = None) -> Dict[str, An
     return {"file": f"/static/{dh}.png"}
 
 
-@app.get("/details")
+@app.get("/details/{type}")
 async def get_details(type: Optional[str] = None) -> dict:
     """Get details about accessories which can be used to build ducks/man-ducks."""
     details = {

--- a/main.py
+++ b/main.py
@@ -87,5 +87,5 @@ async def get_details(type: Optional[str] = None) -> dict:
     }
 
     if type:
-        return details.get(type) or {"message": "Requested type is not available"}
+        return details.get(type, {"message": "Requested type is not available"})
     return details

--- a/main.py
+++ b/main.py
@@ -66,10 +66,26 @@ async def get_man_duck(manduck: Optional[ManDuckRequest] = None) -> Dict[str, An
 
 
 @app.get("/details")
-async def get_details() -> Dict[str, Any]:
-    """Get details about accessories which can be used to build ducks."""
-    return {
-        "hats": list(DuckBuilder.hats.keys()),
-        "outfits": list(DuckBuilder.outfits.keys()),
-        "equipments": list(DuckBuilder.equipments.keys()),
+async def get_details(type: Optional[str] = None) -> dict:
+    """Get details about accessories which can be used to build ducks/man-ducks."""
+    details = {
+        "ducky": {
+            "hats": list(DuckBuilder.hats),
+            "outfits": list(DuckBuilder.outfits),
+            "equipments": list(DuckBuilder.equipments)
+        },
+        "man-duck": {
+            "hats": list(ManDuckGenerator.HATS),
+            "outfits": {
+                variation: list(outfit) for variation, outfit in ManDuckGenerator.OUTFITS.items()
+            },
+            "equipments": {
+                variation: list(equipment) for variation, equipment in ManDuckGenerator.EQUIPMENTS.items()
+            },
+            "variations": list(ManDuckGenerator.VARIATIONS)
+        }
     }
+
+    if type:
+        return details.get(type) or {"message": "Requested type is not available"}
+    return details

--- a/src/manducky.py
+++ b/src/manducky.py
@@ -21,12 +21,32 @@ MAN_DUCKY_SIZE = (600, 1194)
 class ManDuckGenerator:
     """Temporary class used to generate a ducky human."""
 
+    VARIATIONS = (1, 2)
+    HATS = {
+        filename.stem: filename for filename in (ASSETS_PATH / "accessories/hats").iterdir()
+    }
+    OUTFITS = {
+        "variation_1": {
+            filename.stem: filename for filename in (ASSETS_PATH / "outfits/variation_1").iterdir()
+        },
+        "variation_2": {
+            filename.stem: filename for filename in (ASSETS_PATH / "outfits/variation_2").iterdir()
+        }
+    }
+    EQUIPMENTS = {
+        "variation_1": {
+            filename.stem: filename for filename in (ASSETS_PATH / "equipment/variation_1").iterdir()
+        },
+        "variation_2": {
+            filename.stem: filename for filename in (ASSETS_PATH / "equipment/variation_2").iterdir()
+        }
+    }
+
     def __init__(self):
         self.output: Image.Image = Image.new("RGBA", MAN_DUCKY_SIZE, color=(0, 0, 0, 0))
 
-    @staticmethod
     def generate_tempalte(
-            ducky: ProceduralDucky, dress_colors: DressColors, variation_: int
+            self, ducky: ProceduralDucky, dress_colors: DressColors, variation_: int
     ) -> dict:
         """Generate a man duck structure from given configuration."""
         variation = f"variation_{variation_}"
@@ -66,18 +86,11 @@ class ManDuckGenerator:
             )
 
         if ducky.hat:
-            template["hat"] = (
-                ASSETS_PATH / f"accessories/hats/{ducky.hat}.png",
-            )
+            template["hat"] = (self.HATS[ducky.hat],)
         if ducky.outfit:
-            template["outfit"] = (
-                ASSETS_PATH / f"outfits/{variation}/{ducky.outfit}.png",
-            )
+            template["outfit"] = (self.OUTFITS[variation][ducky.outfit],)
         if ducky.equipment:
-            template["equipment"] = (
-                ASSETS_PATH / f"equipment/{variation}/{ducky.equipment}.png",
-            )
-
+            template["equipment"] = (self.EQUIPMENTS[variation][ducky.equipment],)
         return template
 
     def generate_from_options(self, options: dict) -> dict:
@@ -102,7 +115,7 @@ class ManDuckGenerator:
             template = self.generate_from_options(options.dict())
         else:
             template = self.generate_tempalte(
-                ducky, make_man_duck_colors(ducky.colors.body), random.choice((1, 2))
+                ducky, make_man_duck_colors(ducky.colors.body), random.choice(self.VARIATIONS)
             )
 
         for item in template.values():


### PR DESCRIPTION
This commit does two major things, it adds a query parameter called type which takes in a string object of the detail they are requesting i.e. either man-duck or ducky as of now. If it is None, then it would send all the details of all types, otherwise it would send the details only of the requested type.

This commit also adds details for man-duck generation and accordingly alters the man-duck generation class

### Requesting `?type=ducky`
![Screenshot from 2021-05-19 19-40-18](https://user-images.githubusercontent.com/69356296/118827663-3797ab00-b8da-11eb-90b3-31a037349f64.png)


### Requesting `?type=man-duck`
![Screenshot from 2021-05-19 19-40-31](https://user-images.githubusercontent.com/69356296/118827678-3a929b80-b8da-11eb-9c71-26c1075cd3e8.png)


### Requesting invalid `?type=ababab`
![Screenshot from 2021-05-19 19-40-44](https://user-images.githubusercontent.com/69356296/118827697-3d8d8c00-b8da-11eb-9f5d-7c053dff059a.png)

