### PR TITLE
Upgrade to python 3.9

### DIFF
--- a/.github/workflows/quackstack.yml
+++ b/.github/workflows/quackstack.yml
@@ -34,7 +34,7 @@ jobs:
         id: python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       # This step caches our Python dependencies. To make sure we
       # only restore a cache when the dependencies, the python version,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.9
 
 RUN apt update && apt install -y git
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An on-demand procedural ducky delivery service. An infinite stack of duckies!
 
 1. Install Poetry with `pip install poetry`
 2. Install the dependencies with Poetry: `poetry install`
-3. Run the server: `poetry run hypercorn main:app --bind 127.0.0.1:8077`
+3. Run the server: `poetry run uvicorn main:app --host 127.0.0.1 --port 8077`
 
 ### Docker Compose
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -426,8 +426,8 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.8"
-content-hash = "21dbe1a9be7eaaa6214d88d0e235b5e1723fde595b1422ae374a3de99c6339bf"
+python-versions = "^3.9"
+content-hash = "49a16a5645bc2ab8800cd33c61931aa6b09c3f269cbfb6a142390c0626ffc901"
 
 [metadata.files]
 aiofiles = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["vcokltfre <vcokltfre@gmail.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 fastapi = "^0.63.0"
 Pillow = "^8.1.2"
 aiofiles = "^0.6.0"


### PR DESCRIPTION
This PR updates quackstack to python 3.9, and updates `README.md` to use `uvicorn`.