### PR TITLE
feat: endpoint types and correct /details responses

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,9 +3,9 @@ from json import dumps
 from os import getenv
 from pathlib import Path
 from time import time
-from typing import Any, Dict, Optional, Union
+from typing import Optional, Union
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Response
 from fastapi.staticfiles import StaticFiles
 
 from src.ducky import DuckBuilder
@@ -66,7 +66,7 @@ async def get_man_duck(manduck: Optional[ManDuckRequest] = None) -> DuckResponse
 
 
 @app.get("/details/{type}", response_model=Union[ManduckDetails, DuckyDetails])
-async def get_details(type: Optional[str] = None) -> Union[ManduckDetails, DuckyDetails]:
+async def get_details(type: str = None) -> Union[ManduckDetails, DuckyDetails]:
     """Get details about accessories which can be used to build ducks/man-ducks."""
 
     details = {
@@ -89,6 +89,4 @@ async def get_details(type: Optional[str] = None) -> Union[ManduckDetails, Ducky
         )
     }
 
-    if type:
-        return details.get(type, {"message": "Requested type is not available"})
-    return details
+    return details.get(type, Response("Requested type is not available", 400))

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from fastapi.staticfiles import StaticFiles
 
 from src.ducky import DuckBuilder
 from src.manducky import ManDuckGenerator
-from src.models import DuckRequest, ManDuckRequest
+from src.models import DuckRequest, ManDuckRequest, DuckResponse
 
 CACHE = Path(getenv("LOCATION", "./static"))
 
@@ -26,8 +26,8 @@ def dicthash(data: dict) -> str:
     return sha1(dumps(data).encode()).hexdigest()
 
 
-@app.get("/duck")
-async def get_duck(duck: Optional[DuckRequest] = None) -> Dict[str, Any]:
+@app.get("/duck", response_model=DuckResponse)
+async def get_duck(duck: Optional[DuckRequest] = None) -> DuckResponse:
     """Create a new duck."""
     if duck:
         dh = dicthash(duck.dict())
@@ -41,11 +41,11 @@ async def get_duck(duck: Optional[DuckRequest] = None) -> Dict[str, Any]:
 
         DuckBuilder().generate().image.save(file)
 
-    return {"file": f"/static/{dh}.png"}
+    return DuckResponse(file=f"/static/{dh}.png")
 
 
-@app.get("/manduck")
-async def get_man_duck(manduck: Optional[ManDuckRequest] = None) -> Dict[str, Any]:
+@app.get("/manduck", response_model=DuckResponse)
+async def get_man_duck(manduck: Optional[ManDuckRequest] = None) -> DuckResponse:
     """Create a new man_duck."""
     if manduck:
         dh = dicthash(manduck.dict())
@@ -62,7 +62,7 @@ async def get_man_duck(manduck: Optional[ManDuckRequest] = None) -> Dict[str, An
         ducky = ManDuckGenerator().generate(ducky=ducky)
         ducky.image.save(CACHE / f"{dh}.png")
 
-    return {"file": f"/static/{dh}.png"}
+    return DuckResponse(file=f"/static/{dh}.png")
 
 
 @app.get("/details/{type}")

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from fastapi.staticfiles import StaticFiles
 
 from src.ducky import DuckBuilder
 from src.manducky import ManDuckGenerator
-from src.models import DuckRequest, ManDuckRequest, DuckResponse, DuckyDetails, ManduckDetails, ManduckVariations
+from src.models import DuckRequest, DuckResponse, DuckyDetails, ManDuckRequest, ManduckDetails, ManduckVariations
 
 CACHE = Path(getenv("LOCATION", "./static"))
 
@@ -68,7 +68,6 @@ async def get_man_duck(manduck: Optional[ManDuckRequest] = None) -> DuckResponse
 @app.get("/details/{type}", response_model=Union[ManduckDetails, DuckyDetails])
 async def get_details(type: str = None) -> Union[ManduckDetails, DuckyDetails]:
     """Get details about accessories which can be used to build ducks/man-ducks."""
-
     details = {
         "ducky": DuckyDetails(
             hats=list(DuckBuilder.hats),

--- a/src/models.py
+++ b/src/models.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 
 from pydantic import BaseModel
 
@@ -54,3 +54,21 @@ class ManDuckRequest(BaseModel):
 
 class DuckResponse(BaseModel):
     file: str
+
+
+class DuckyDetails(BaseModel):
+    hats: List[str]
+    outfits: List[str]
+    equipments: List[str]
+
+
+class ManduckVariations(BaseModel):
+    variation_1: List[str]
+    variation_2: List[str]
+
+
+class ManduckDetails(BaseModel):
+    hats: List[str]
+    outfits: ManduckVariations
+    equipments: ManduckVariations
+    variations: List[int]

--- a/src/models.py
+++ b/src/models.py
@@ -50,3 +50,7 @@ class ManDuckRequest(BaseModel):
     colors: Colors
     dress_colors: DressColors
     accessories: Accessories
+
+
+class DuckResponse(BaseModel):
+    file: str

--- a/src/models.py
+++ b/src/models.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -61,22 +61,22 @@ class DuckResponse(BaseModel):
 class DuckyDetails(BaseModel):
     """Details of available ducky creation assets."""
 
-    hats: List[str]
-    outfits: List[str]
-    equipments: List[str]
+    hats: list[str]
+    outfits: list[str]
+    equipments: list[str]
 
 
 class ManduckVariations(BaseModel):
     """Details of available manduck variations."""
 
-    variation_1: List[str]
-    variation_2: List[str]
+    variation_1: list[str]
+    variation_2: list[str]
 
 
 class ManduckDetails(BaseModel):
     """Details of available manduck creation assets."""
 
-    hats: List[str]
+    hats: list[str]
     outfits: ManduckVariations
     equipments: ManduckVariations
-    variations: List[int]
+    variations: list[int]

--- a/src/models.py
+++ b/src/models.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import List, Optional
 
 from pydantic import BaseModel
 
@@ -53,21 +53,29 @@ class ManDuckRequest(BaseModel):
 
 
 class DuckResponse(BaseModel):
+    """The generated ducky file location."""
+
     file: str
 
 
 class DuckyDetails(BaseModel):
+    """Details of available ducky creation assets."""
+
     hats: List[str]
     outfits: List[str]
     equipments: List[str]
 
 
 class ManduckVariations(BaseModel):
+    """Details of available manduck variations."""
+
     variation_1: List[str]
     variation_2: List[str]
 
 
 class ManduckDetails(BaseModel):
+    """Details of available manduck creation assets."""
+
     hats: List[str]
     outfits: ManduckVariations
     equipments: ManduckVariations


### PR DESCRIPTION
- Response types have been added to /duck, /manduck, and /details
- /details now requires a type
- /details will return a status 400 response on invalid types