### PR TITLE
chore: add start-dev task

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ An on-demand procedural ducky delivery service. An infinite stack of duckies!
 2. Install the dependencies with Poetry: `poetry install`
 3. Run the server: `poetry run uvicorn main:app --host 127.0.0.1 --port 8077`
 
+Note: to run the server for development you can use `poetry run task start-dev` which will start the server on port 8000.
+
 ### Docker Compose
 
 #### Linux

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ taskipy = "^1.6.0"
 [tool.taskipy.tasks]
 lint = "pre-commit run --all-files"
 precommit = "pre-commit install"
+start-dev = "uvicorn main:app --reload"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
This PR adds the ability to run `poetry run task start-dev` to start uvicorn quickly for development with the reload option enabled