### PR TITLE
feat: add the ability to set seeds for ducks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN poetry install --no-dev
 
 COPY . /app
 
-CMD ["poetry", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80"]
+CMD ["poetry", "run", "uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "80"]

--- a/api/main.py
+++ b/api/main.py
@@ -35,7 +35,7 @@ def dicthash(data: dict) -> str:
 
 
 @app.get("/duck", response_model=DuckResponse)
-async def get_duck(duck: Optional[DuckRequest] = None) -> DuckResponse:
+async def get_duck(duck: Optional[DuckRequest] = None, seed: int = None) -> DuckResponse:
     """Create a new duck."""
     if duck:
         dh = dicthash(duck.dict())
@@ -43,7 +43,7 @@ async def get_duck(duck: Optional[DuckRequest] = None) -> DuckResponse:
 
         if not file.exists():
             try:
-                DuckBuilder().generate(options=duck.dict()).image.save(file)
+                DuckBuilder(seed).generate(options=duck.dict()).image.save(file)
             except ValueError as e:
                 raise HTTPException(400, e.args[0])
             except KeyError as e:
@@ -58,7 +58,7 @@ async def get_duck(duck: Optional[DuckRequest] = None) -> DuckResponse:
 
 
 @app.get("/manduck", response_model=DuckResponse)
-async def get_man_duck(manduck: Optional[ManDuckRequest] = None) -> DuckResponse:
+async def get_man_duck(manduck: Optional[ManDuckRequest] = None, seed: int = None) -> DuckResponse:
     """Create a new man_duck."""
     if manduck:
         dh = dicthash(manduck.dict())
@@ -66,7 +66,7 @@ async def get_man_duck(manduck: Optional[ManDuckRequest] = None) -> DuckResponse
 
         if not file.exists():
             try:
-                ducky = ManDuckBuilder().generate(options=manduck.dict())
+                ducky = ManDuckBuilder(seed).generate(options=manduck.dict())
             except ValueError as e:
                 raise HTTPException(400, e.args[0])
             except KeyError as e:

--- a/api/main.py
+++ b/api/main.py
@@ -35,7 +35,7 @@ def dicthash(data: dict) -> str:
 
 
 @app.get("/duck", response_model=DuckResponse)
-async def get_duck(duck: Optional[DuckRequest] = None, seed: int = None) -> DuckResponse:
+async def get_duck(duck: Optional[DuckRequest] = None, seed: Optional[int] = None) -> DuckResponse:
     """Create a new duck."""
     if duck:
         dh = dicthash(duck.dict())
@@ -58,7 +58,7 @@ async def get_duck(duck: Optional[DuckRequest] = None, seed: int = None) -> Duck
 
 
 @app.get("/manduck", response_model=DuckResponse)
-async def get_man_duck(manduck: Optional[ManDuckRequest] = None, seed: int = None) -> DuckResponse:
+async def get_man_duck(manduck: Optional[ManDuckRequest] = None, seed: Optional[int] = None) -> DuckResponse:
     """Create a new man_duck."""
     if manduck:
         dh = dicthash(manduck.dict())

--- a/quackstack/ducky.py
+++ b/quackstack/ducky.py
@@ -31,8 +31,8 @@ class DuckBuilder:
         filename.stem: filename for filename in (ASSETS_PATH / "accessories/outfits").iterdir()
     }
 
-    def __init__(self, seed: int = None):
-        self.random = Random(seed) if seed else Random()
+    def __init__(self, seed: Optional[int] = None):
+        self.random = Random(seed)
         self.output: Image.Image = Image.new("RGBA", DUCK_SIZE, color=(0, 0, 0, 0))
 
     def generate_template(

--- a/quackstack/ducky.py
+++ b/quackstack/ducky.py
@@ -1,7 +1,7 @@
 import os
 from collections import namedtuple
 from pathlib import Path
-from random import choice
+from random import Random
 from typing import Optional, Tuple
 
 from PIL import Image, ImageChops
@@ -31,7 +31,8 @@ class DuckBuilder:
         filename.stem: filename for filename in (ASSETS_PATH / "accessories/outfits").iterdir()
     }
 
-    def __init__(self):
+    def __init__(self, seed: int = None):
+        self.random = Random(seed) if seed else Random()
         self.output: Image.Image = Image.new("RGBA", DUCK_SIZE, color=(0, 0, 0, 0))
 
     def generate_template(
@@ -69,9 +70,9 @@ class DuckBuilder:
         else:
             template, colors, hat, outfit, equipment = self.generate_template(
                 make_duck_colors(),
-                choice([*list(self.hats), None]),
-                choice([*list(self.outfits), None]),
-                choice([*list(self.equipments), None])
+                self.random.choice([*list(self.hats), None]),
+                self.random.choice([*list(self.outfits), None]),
+                self.random.choice([*list(self.equipments), None])
             )
 
         for item in template.values():

--- a/quackstack/manducky.py
+++ b/quackstack/manducky.py
@@ -41,8 +41,8 @@ class ManDuckBuilder:
         }
     }
 
-    def __init__(self, seed: int = None):
-        self.random = Random(seed) if seed else Random()
+    def __init__(self, seed: Optional[int] = None):
+        self.random = Random(seed)
         self.output: Image.Image = Image.new("RGBA", MAN_DUCKY_SIZE, color=(0, 0, 0, 0))
 
     def generate_tempalte(

--- a/quackstack/manducky.py
+++ b/quackstack/manducky.py
@@ -1,7 +1,7 @@
 import os
-import random
 from collections import namedtuple
 from pathlib import Path
+from random import Random
 from typing import Optional, Tuple
 
 from PIL import Image, ImageChops
@@ -41,7 +41,8 @@ class ManDuckBuilder:
         }
     }
 
-    def __init__(self):
+    def __init__(self, seed: int = None):
+        self.random = Random(seed) if seed else Random()
         self.output: Image.Image = Image.new("RGBA", MAN_DUCKY_SIZE, color=(0, 0, 0, 0))
 
     def generate_tempalte(
@@ -114,7 +115,7 @@ class ManDuckBuilder:
             template = self.generate_from_options(options)
         else:
             template = self.generate_tempalte(
-                ducky, make_man_duck_colors(ducky.colors.body), random.choice(self.VARIATIONS)
+                ducky, make_man_duck_colors(ducky.colors.body), self.random.choice(self.VARIATIONS)
             )
 
         for item in template.values():


### PR DESCRIPTION
/duck and /manduck both now support a seed query param to use a seed to generate a duck. The seed is an integer, for example `GET /duck?seed=1234`

This also fixes the fact that quackstack wont start because the dockerfile was using an outdated location for the main file.