### PR TITLE
fix: apply layers in correct order

### DIFF
--- a/quackstack/ducky.py
+++ b/quackstack/ducky.py
@@ -75,8 +75,9 @@ class DuckBuilder:
                 self.random.choice([*list(self.equipments), None])
             )
 
-        for item in template.values():
-            self.apply_layer(*item)
+        for key in ["beak", "body", "eye", "equipment", "wing", "eye_wing", "hat", "outfit"]:
+            if item := template.get(key):
+                self.apply_layer(*item)
 
         return ProceduralDucky(self.output, colors, hat, equipment, outfit)
 


### PR DESCRIPTION
The equipment layer is now applied before the wing layer

Before:
![image](https://user-images.githubusercontent.com/16879430/135769276-97383e2d-c7e6-4ae6-b4a7-b239d02f0dbb.png)

After:
![56879acff131ae4a62ba48fa13931fff796f5e56](https://user-images.githubusercontent.com/16879430/135769251-7f509fab-1ae4-41dc-9cff-1a63f668f4fa.png)
