### PR TITLE
chore: improve efficiency of docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-buster
+FROM --platform=linux/amd64 python:3.9-slim-buster
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM python:3.9
-
-RUN apt update && apt install -y git
+FROM python:3.9-slim-buster
 
 WORKDIR /app
 


### PR DESCRIPTION
- Removed installing git since it's not required (used to be used for cloning submodules)
- Using slim-buster for python to improve download time