### PR TITLE
chore: remove flake8 import order in favour of isort

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,6 @@
 [flake8]
 max-line-length=120
 docstring-convention=all
-import-order-style=pycharm
 application_import_names=src
 exclude=.cache,.venv,.git
 ignore=

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,8 @@ repos:
         language: system
         types: [python]
         require_serial: true
+  - repo: https://github.com/pycqa/isort
+    rev: 5.8.0
+    hooks:
+      - id: isort
+        name: isort (python)

--- a/api/main.py
+++ b/api/main.py
@@ -5,13 +5,13 @@ from pathlib import Path
 from time import time
 from typing import Optional, Union
 
-from api.models import DuckRequest, DuckResponse, DuckyDetails, ManDuckRequest, ManduckDetails, ManduckVariations
 from fastapi import FastAPI, Response
 from fastapi.exceptions import HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
-from quackstack import DuckBuilder, ManDuckBuilder
 
+from api.models import DuckRequest, DuckResponse, DuckyDetails, ManDuckRequest, ManduckDetails, ManduckVariations
+from quackstack import DuckBuilder, ManDuckBuilder
 
 CACHE = Path(getenv("LOCATION", "./static"))
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -138,15 +138,20 @@ flake8 = ">=3"
 pydocstyle = ">=2.1"
 
 [[package]]
-name = "flake8-import-order"
-version = "0.18.1"
-description = "Flake8 and pylama plugin that checks the ordering of import statements."
+name = "flake8-isort"
+version = "4.1.1"
+description = "flake8 plugin that integrates isort ."
 category = "dev"
 optional = false
 python-versions = "*"
 
 [package.dependencies]
-pycodestyle = "*"
+flake8 = ">=3.2.1,<5"
+isort = ">=4.3.5,<6"
+testfixtures = ">=6.8.0,<7"
+
+[package.extras]
+test = ["pytest-cov"]
 
 [[package]]
 name = "flake8-polyfill"
@@ -210,6 +215,20 @@ python-versions = ">=3.6.1"
 
 [package.extras]
 license = ["editdistance-s"]
+
+[[package]]
+name = "isort"
+version = "5.9.3"
+description = "A Python utility / library to sort Python imports."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1,<4.0"
+
+[package.extras]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
+requirements_deprecated_finder = ["pipreqs", "pip-api"]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
+plugins = ["setuptools"]
 
 [[package]]
 name = "mccabe"
@@ -376,6 +395,19 @@ psutil = ">=5.7.2,<6.0.0"
 toml = ">=0.10.0,<0.11.0"
 
 [[package]]
+name = "testfixtures"
+version = "6.18.3"
+description = "A collection of helpers and mock objects for unit tests and doc tests."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.extras]
+build = ["setuptools-git", "wheel", "twine"]
+docs = ["sphinx", "zope.component", "sybil", "twisted", "mock", "django (<2)", "django"]
+test = ["pytest (>=3.6)", "pytest-cov", "pytest-django", "zope.component", "sybil", "twisted", "mock", "django (<2)", "django"]
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -427,7 +459,7 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "ec498569aafba61d987e6f6431f15ed1860704f99fc781f128a6757d5174bf20"
+content-hash = "0054c6ac8fc563bba9e84b516538107a2ce4b62a6b038fd48506d0b865227045"
 
 [metadata.files]
 aiofiles = [
@@ -482,9 +514,9 @@ flake8-docstrings = [
     {file = "flake8-docstrings-1.6.0.tar.gz", hash = "sha256:9fe7c6a306064af8e62a055c2f61e9eb1da55f84bb39caef2b84ce53708ac34b"},
     {file = "flake8_docstrings-1.6.0-py2.py3-none-any.whl", hash = "sha256:99cac583d6c7e32dd28bbfbef120a7c0d1b6dde4adb5a9fd441c4227a6534bde"},
 ]
-flake8-import-order = [
-    {file = "flake8-import-order-0.18.1.tar.gz", hash = "sha256:a28dc39545ea4606c1ac3c24e9d05c849c6e5444a50fb7e9cdd430fc94de6e92"},
-    {file = "flake8_import_order-0.18.1-py2.py3-none-any.whl", hash = "sha256:90a80e46886259b9c396b578d75c749801a41ee969a235e163cfe1be7afd2543"},
+flake8-isort = [
+    {file = "flake8-isort-4.1.1.tar.gz", hash = "sha256:d814304ab70e6e58859bc5c3e221e2e6e71c958e7005239202fee19c24f82717"},
+    {file = "flake8_isort-4.1.1-py3-none-any.whl", hash = "sha256:c4e8b6dcb7be9b71a02e6e5d4196cefcef0f3447be51e82730fb336fff164949"},
 ]
 flake8-polyfill = [
     {file = "flake8-polyfill-1.0.2.tar.gz", hash = "sha256:e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda"},
@@ -508,6 +540,10 @@ h11 = [
 identify = [
     {file = "identify-2.2.4-py2.py3-none-any.whl", hash = "sha256:ad9f3fa0c2316618dc4d840f627d474ab6de106392a4f00221820200f490f5a8"},
     {file = "identify-2.2.4.tar.gz", hash = "sha256:9bcc312d4e2fa96c7abebcdfb1119563b511b5e3985ac52f60d9116277865b2e"},
+]
+isort = [
+    {file = "isort-5.9.3-py3-none-any.whl", hash = "sha256:e17d6e2b81095c9db0a03a8025a957f334d6ea30b26f9ec70805411e5c7c81f2"},
+    {file = "isort-5.9.3.tar.gz", hash = "sha256:9c2ea1e62d871267b78307fe511c0838ba0da28698c5732d54e2790bf3ba9899"},
 ]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
@@ -677,6 +713,10 @@ starlette = [
 taskipy = [
     {file = "taskipy-1.8.1-py3-none-any.whl", hash = "sha256:2b98f499966e40175d1f1306a64587f49dfa41b90d0d86c8f28b067cc58d0a56"},
     {file = "taskipy-1.8.1.tar.gz", hash = "sha256:7a2404125817e45d80e13fa663cae35da6e8ba590230094e815633653e25f98f"},
+]
+testfixtures = [
+    {file = "testfixtures-6.18.3-py2.py3-none-any.whl", hash = "sha256:6ddb7f56a123e1a9339f130a200359092bd0a6455e31838d6c477e8729bb7763"},
+    {file = "testfixtures-6.18.3.tar.gz", hash = "sha256:2600100ae96ffd082334b378e355550fef8b4a529a6fa4c34f47130905c7426d"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,18 +17,26 @@ flake8 = "^3.8"
 flake8-annotations = "^2.3"
 flake8-bugbear = "^21.4.3"
 flake8-docstrings = "^1.5"
-flake8-import-order = "^0.18"
 flake8-string-format = "^0.3"
 flake8-tidy-imports = "^4.1"
 flake8-todo = "^0.7"
 pep8-naming = "^0.11"
 pre-commit = "^2.1"
 taskipy = "^1.6.0"
+flake8-isort = "^4.1.1"
 
 [tool.taskipy.tasks]
 lint = "pre-commit run --all-files"
 precommit = "pre-commit install"
 start-dev = "uvicorn api.main:app --reload"
+isort = "isort ."
+
+[tool.isort]
+multi_line_output = 6
+order_by_type = false
+case_sensitive = true
+combine_as_imports = true
+line_length = 120
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/quackstack/__init__.py
+++ b/quackstack/__init__.py
@@ -1,7 +1,6 @@
 from .ducky import DuckBuilder
 from .manducky import ManDuckBuilder
 
-
 __all__ = (
     "DuckBuilder",
     "ManDuckBuilder",

--- a/quackstack/ducky.py
+++ b/quackstack/ducky.py
@@ -5,6 +5,7 @@ from random import Random
 from typing import Optional, Tuple
 
 from PIL import Image, ImageChops
+
 from quackstack import __file__ as qs_file
 
 from .colors import DuckyColors, make_duck_colors

--- a/quackstack/manducky.py
+++ b/quackstack/manducky.py
@@ -5,6 +5,7 @@ from random import Random
 from typing import Optional, Tuple
 
 from PIL import Image, ImageChops
+
 from quackstack import __file__ as qs_file
 
 from .colors import DressColors, DuckyColors, make_man_duck_colors


### PR DESCRIPTION
Similar to bot#1872 this removes flake8 import order and replaces it with isort