### PR TITLE
Fix duck paths being returned incorrectly if a query parameter is present.

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -36,8 +36,8 @@ def dicthash(data: dict) -> str:
 
 def make_file_path(dh: str, request_url: URL) -> str:
     """Build a file path from dict_hash and a URL."""
-    fqdn = str(request_url).removesuffix(request_url.path)
-    return f"{fqdn}/static/{dh}.png"
+    path = f"/static/{dh}.png"
+    return str(request_url.replace(query="", path=path))
 
 
 @app.get("/duck", status_code=201)


### PR DESCRIPTION
Doing string manipulation breaks with queries in url, this PR instead uses the URL API of fastAPI.

fixes #81 